### PR TITLE
Remove stale prices, use map for better efficiency

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/adshao/go-binance/v2"
@@ -13,12 +14,22 @@ import (
 
 func replaceBid(newBid *binance.Bid, bids map[string]string) {
 
-	bids[newBid.Price] = newBid.Quantity
+	f, _ := strconv.ParseFloat(newBid.Quantity, 64)
+	if f == 0.0 {
+		delete(bids, newBid.Price)
+	} else {
+		bids[newBid.Price] = newBid.Quantity
+	}
 }
 
 func replaceAsk(newAsk *binance.Ask, asks map[string]string) {
 
-	asks[newAsk.Price] = newAsk.Quantity
+	f, _ := strconv.ParseFloat(newAsk.Quantity, 64)
+	if f == 0.0 {
+		delete(asks, newAsk.Price)
+	} else {
+		asks[newAsk.Price] = newAsk.Quantity
+	}
 }
 
 func displayOrderBook(bids map[string]string, asks map[string]string) {
@@ -94,7 +105,7 @@ func main() {
 	}
 	// use stopC to exit
 	go func() {
-		time.Sleep(5 * time.Second)
+		time.Sleep(50 * time.Second)
 		stopC <- struct{}{}
 	}()
 	// remove this if you do not want to be blocked here


### PR DESCRIPTION
PR to move from using Array->Map to make it simpler to remove 'stale' prices as per [docs](https://github.com/binance/binance-spot-api-docs/blob/master/web-socket-streams.md#how-to-manage-a-local-order-book-correctly).

Still needs some work on sorting. Should really move to using float values as opposed to strings.